### PR TITLE
Change 'merge' to symbol in tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ end
 
 
 # Items used for testing sort algorithms
-sorts = [:insert, :bubble, :select, :quick, merge]
+sorts = [:insert, :bubble, :select, :quick, :merge]
 c = [23, 12, 17, 88, 90, 26, 34, 129]
 
 # Sorting Tests


### PR DESCRIPTION
I don't think this would work if `merge` is not a symbol.. Can you check?
